### PR TITLE
add noCache and useTemp options to constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pgfmanual.pdf
 docsource/_*
 scratch.ipynb
 2010-TickLabels-InfoVis.pdf
+/pytikz.egg-info

--- a/tikz/__init__.py
+++ b/tikz/__init__.py
@@ -1004,14 +1004,20 @@ class Picture(Scope):
     [§12.2.1](https://pgf-tikz.github.io/pgf/pgfmanual.pdf#subsubsection.12.2.1)
     """
 
-    def __init__(self, opt=None, **kwoptions):
+    def __init__(self, opt=None, useTemp='', noCache=False, **kwoptions):
+        # permit user to select "temp" directory for LaTeX processing.
+        # set noCache to `True` to always rebuild
         super().__init__(opt=opt, **kwoptions)
         # additional preamble entries
         self.preamble = []
+        self.noCache = noCache
         # create temporary directory for pdflatex etc.
-        self.tempdir = tempfile.mkdtemp(prefix='tikz-')
-        # make sure it gets deleted
-        atexit.register(shutil.rmtree, self.tempdir, ignore_errors=True)
+        if not useTemp:
+            self.tempdir = tempfile.mkdtemp(prefix='tikz-')
+            # make sure it gets deleted
+            atexit.register(shutil.rmtree, self.tempdir, ignore_errors=True)
+        else:
+            self.tempdir=useTemp
 
     def add_preamble(self, code):
         """
@@ -1113,7 +1119,7 @@ class Picture(Scope):
         # in the PDF filename, and to skip creation if that file exists.
         hash = hashlib.sha1(code.encode()).hexdigest()
         self.temp_pdf = self.tempdir + sep + 'tikz-' + hash + '.pdf'
-        if os.path.isfile(self.temp_pdf):
+        if not self.noCache and os.path.isfile(self.temp_pdf):
             return
 
         # create LaTeX file


### PR DESCRIPTION
I love this package! However, I'm using `pytikz` to overlay drawings on top of images. This is not supported since the directory where pdflatex is run is created (by default) in an indeterminate location by `tempfile`. The `useTemp` option allows users to specify where the temp files are created. The `noCache` option just allows for the option to skip the caching of pdf files (if the image you're drawing on changes, it won't change the tik code, so the cache mechanism thinks that nothing has changed).

